### PR TITLE
fix typo in get_queues() when vhost is specified

### DIFF
--- a/pyrabbit/api.py
+++ b/pyrabbit/api.py
@@ -402,7 +402,7 @@ class Client(object):
 
         """
         if vhost:
-            path = Client.urls['all_queues'] % vhost
+            path = Client.urls['queues_by_vhost'] % vhost
         else:
             path = Client.urls['all_queues']
 


### PR DESCRIPTION
hey, nice RabbitMQ management API library!  while grabbing some queues by vhost I noticed a typo in get_queues().
