### PR TITLE
fixed api url creation to support windows

### DIFF
--- a/pyrabbit/http.py
+++ b/pyrabbit/http.py
@@ -3,6 +3,7 @@ import json
 import os
 import socket
 import httplib2
+import urlparse
 
 
 class HTTPError(Exception):
@@ -62,7 +63,7 @@ class HTTPClient(object):
 
         self.client = httplib2.Http(timeout=timeout)
         self.client.add_credentials(uname, passwd)
-        self.base_url = 'http://%s/api' % server
+        self.base_url = 'http://%s/api/' % server
 
     def decode_json_content(self, content):
         """

--- a/tests/test_httpclient.py
+++ b/tests/test_httpclient.py
@@ -3,6 +3,8 @@ try:
 except ImportError:
     import unittest
 
+import mock
+import httplib2
 import sys
 sys.path.append('..')
 from pyrabbit import http
@@ -35,3 +37,21 @@ class TestHTTPClient(unittest.TestCase):
         c = http.HTTPClient('localhost:55672', 'guest', 'guest', 1)
         self.assertEqual(c.client.timeout, 1)
 
+    def test_base_url(self):
+        self.assertEquals('http://localhost:55672/api/', self.c.base_url)
+
+    @mock.patch('httplib2.Http', spec=httplib2.Http)
+    def test_url_path_creation(self, httplib):
+        client = mock.Mock()
+        httplib.return_value = client
+        c = http.HTTPClient('localhost:55672', 'guest', 'guest')
+        resp = mock.Mock()
+        resp.status = 200
+        client.request.return_value = (resp, None)
+        c.do_call('queues', 'GET')
+        client.request.assert_called_once_with(
+            'http://localhost:55672/api/queues',
+            'GET', 
+            None,
+            None
+        )


### PR DESCRIPTION
In Windows the api urls being generated in `http.HTTPClient.do_call` were looking like this: `http://localhost:15672/api\\queues`.

Adding the trailing `/` to `http.HTTPClient.base_url` fixes it.

I'm going to go cry myself to sleep now having contributed a Windows fix.
