### PR TITLE
Add default values for api.Client __init__ parameters

### DIFF
--- a/pyrabbit/api.py
+++ b/pyrabbit/api.py
@@ -91,17 +91,27 @@ class Client(object):
 
     json_headers = {"content-type": "application/json"}
 
-    def __init__(self, host, user, passwd, timeout=5):
+    def __init__(self, host='localhost', user='guest', passwd='guest',
+                 port=55672, timeout=5):
         """
-        :param string host: string of the form 'host:port'
-        :param string user: username used to authenticate to the API.
-        :param string passwd: password used to authenticate to the API.
+        :param string host: string of the form 'host[:port]' (default:
+            `localhost`).
+        :param string user: username used to authenticate to the API (default:
+            `guest`).
+        :param string passwd: password used to authenticate to the API
+            (default: `guest`).
+        :param int port: port to use if no port is specified in the `host`
+            string (default: `55672`).
+        :param int timeout: maximum number of seconds to wait for each API
+            call (default: `5`).
 
         Populates server attributes using passed-in parameters and
         the HTTP API's 'overview' information. It also instantiates
-        an httplib2 HTTP client and adds credentia    ls
+        an httplib2 HTTP client and adds credentials.
 
         """
+        if ':' not in host:
+            host += ':{0:d}'.format(port)
         self.host = host
         self.user = user
         self.passwd = passwd

--- a/tests/test_pyrabbit.py
+++ b/tests/test_pyrabbit.py
@@ -14,6 +14,43 @@ sys.path.append('..')
 import pyrabbit
 from mock import Mock, patch
 
+
+class TestClientInit(unittest.TestCase):
+
+    def setUp(self):
+        self.client = pyrabbit.api.Client()
+
+    def tearDown(self):
+        del self.client
+
+    def test_default_host(self):
+        self.assertEqual(self.client.host, 'localhost:55672')
+
+    def test_default_user(self):
+        self.assertEqual(self.client.user, 'guest')
+
+    def test_default_password(self):
+        self.assertEqual(self.client.passwd, 'guest')
+
+    def test_default_timeout(self):
+        self.assertEqual(self.client.timeout, 5)
+
+
+class TestClientHostPort(unittest.TestCase):
+
+    def test_default_port(self):
+        client = pyrabbit.api.Client('localhost')
+        self.assertEqual(client.host, 'localhost:55672')
+
+    def test_port_in_host_string(self):
+        client = pyrabbit.api.Client('localhost:15672')
+        self.assertEqual(client.host, 'localhost:15672')
+
+    def test_custom_port(self):
+        client = pyrabbit.api.Client(port=15672)
+        self.assertEqual(client.host, 'localhost:15672')
+
+
 class TestClient(unittest.TestCase):
     def setUp(self):
         self.client = pyrabbit.api.Client('localhost:55672', 'guest', 'guest')


### PR DESCRIPTION
Add sane defaults for host, port, user, and passwd.  Allow port
to be passed as a separate parameter.  Document timeout
parameter.
