### PR TITLE
Adding RabbitMQ Permission information methods for all, user, and vhost specific permissions.

### DIFF
--- a/pyrabbit/api.py
+++ b/pyrabbit/api.py
@@ -344,6 +344,17 @@ class Client(object):
         path = Client.urls['vhost_permissions'] % (vname, username)
         return self.http.do_call(path, 'DELETE')
 
+    def get_permission(self, vname, username):
+        """
+        :returns: dicts of permissions.
+
+        :param string vname: Name of the vhost to set perms on.
+        :param string username: User to set permissions for.
+        """
+        vname = '%2F' if vname == '/' else vname
+        path = Client.urls['vhost_permissions'] % (vname, username)
+        return self.http.do_call(path, 'GET')
+
     ###############################################
     ##           EXCHANGES
     ###############################################


### PR DESCRIPTION
The RabbitMQ Admin enables access to permission information.  pyrabbit didn't have wrappers for those API calls so I added them.
