### PR TITLE
Added tests and fix for empty queues occasionally omitting the 'messages' key

### DIFF
--- a/pyrabbit/api.py
+++ b/pyrabbit/api.py
@@ -467,7 +467,11 @@ class Client(object):
         vhost = '%2F' if vhost == '/' else vhost
         path = Client.urls['queues_by_name'] % (vhost, name)
         queue = self.http.do_call(path,'GET')
-        depth = queue['messages']
+        # Sometimes, empty queues omit the 'messages' key
+        if 'messages' in queue:
+            depth = queue['messages']
+        else:
+            depth = 0
 
         return depth
 

--- a/tests/test_pyrabbit.py
+++ b/tests/test_pyrabbit.py
@@ -84,6 +84,15 @@ class TestClient(unittest.TestCase):
         depth = self.client.get_queue_depth('/', 'test')
         self.assertEqual(depth, q['messages'])
 
+    def test_get_queue_depth_empty_queue(self):
+        """
+        Sometimes, empty queues omit the 'messages' key. Need to handle this.
+        """
+        q = {}
+        self.client.http.do_call = Mock(return_value=q)
+        depth = self.client.get_queue_depth('/', 'test')
+        self.assertEqual(depth, 0)
+
     def test_get_queue_depth_2(self):
         """
         An integration test that includes the HTTP client's do_call


### PR DESCRIPTION
Sometimes, it seems, Rabbit will omit the `messages` key from `/api/queues/vhost/name` for empty queues.

I don't really understand this behavior, and its not documented in [RabbitMQ's HTTP API docs](http://hg.rabbitmq.com/rabbitmq-management/raw-file/rabbitmq_v2_8_1/priv/www/api/index.html), but I've observed it a few times, both with pyrabbit and with the Network tab of the Chrome Inspector while using the HTTP Management webui. Since their webui doesn't seem to mind its omission, I figured pyrabbit should also not mind this, and assume that the queue is empty when `messages` is not reported.
