### PR TITLE
Add change_password alias for create_user method

### DIFF
--- a/pyrabbit/api.py
+++ b/pyrabbit/api.py
@@ -825,6 +825,17 @@ class Client(object):
         return self.http.do_call(path, 'PUT', body=body,
                                  headers=Client.json_headers)
 
+    def change_password(self, username, password, tags=""):
+        """
+        Changes the password for a user.
+
+        :param string username: The name of the user whose password is to be changed.
+        :param string password: The new password for the user.
+        :param string tags: Comma-separated list of tags for the user
+        :returns: boolean
+        """
+        return self.create_user(username, password, tags)
+
     def delete_user(self, username):
         """
         Deletes a user from the server.

--- a/tests/test_pyrabbit.py
+++ b/tests/test_pyrabbit.py
@@ -172,6 +172,10 @@ class TestClient(unittest.TestCase):
         self.client.http.do_call = Mock(return_value=True)
         self.assertTrue(self.client.create_user('user', 'password'))
 
+    def test_change_password(self):
+        self.client.http.do_call = Mock(return_value=True)
+        self.assertTrue(self.client.change_password('user', 'password22'))
+
     def test_delete_user(self):
         self.client.http.do_call = Mock(return_value=True)
         self.assertTrue(self.client.delete_user('user'))


### PR DESCRIPTION
A PUT request to the [RabbitMQ API](http://hg.rabbitmq.com/rabbitmq-management/raw-file/3646dee55e02/priv/www-api/help.html) /api/users/name endpoint works like the [rabbitmqctl](http://www.rabbitmq.com/man/rabbitmqctl.1.man.html) change_passowrd command if the user was previously created.  If the user was not previously created then a new user is added with the specified password.


